### PR TITLE
Removing tcp_max_per_addr from default_config hash

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,7 +63,6 @@ class auditd (
     'disk_full_action'        => 'SUSPEND',
     'disk_error_action'       => 'SUSPEND',
     'tcp_listen_queue'        => 5,
-    'tcp_max_per_addr'        => 1,
     'tcp_client_max_idle'     => 0,
     'enable_krb5'             => 'no',
     'krb5_principal'          => 'auditd'


### PR DESCRIPTION
Please consider this PR to solve an issue on auditd version 1.7.13 in Ubuntu where tcp_max_per_addr is not a valid option in auditd.conf.
There is no way to remove this key from the default_options using the config_override parameter.
This change seems safe since the default for tcp_max_per_addr is already 1 client connection per the auditd.conf documentation.
